### PR TITLE
fix: use an absolute URL to point to cookie policy

### DIFF
--- a/src/cookies/cookie-banner.html
+++ b/src/cookies/cookie-banner.html
@@ -25,7 +25,7 @@
         <div class="actions">
           <button id="accept-cookies" class="govuk-button govuk-!-margin-right-3">Yes</button>
           <button id="refuse-cookies" class="govuk-button govuk-!-margin-right-3">No</button>
-          <a class="govuk-body govuk-link govuk-link--no-visited-state" href="/cookies">How GovWifi uses cookies.</a>
+          <a class="govuk-body govuk-link govuk-link--no-visited-state" href="https://www.wifi.service.gov.uk/cookies/">How GovWifi uses cookies.</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Since the Admin and Docs site don't host that page.