### PR TITLE
Feat/allow managing categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Indicate whether the user has agreed to that category of cookies. The
 only category at the moment is `analytics` (and `essential`, but that
 will always return true).
 
+#### `GovWifi.cookies.setCategoryAllowed(categoryName, isAllowed)`
+Amend the cookie policy to allow or disable the given
+`categoryName`. If `categoryName` is not recognised do nothing.
+
 ## TODO
 
 - [X] add webpack to streamline distribution;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Frontend functionality shared by the GovWifi websites",
   "main": "dist/govwifi-shared-frontend.js",
   "files": [

--- a/src/cookies/checkCookiePolicy.js
+++ b/src/cookies/checkCookiePolicy.js
@@ -88,7 +88,9 @@ function setCookiePreferences(policy) {
   setCookie("cookie_preferences", JSON.stringify(policy));
   setCookie("cookie_preferences_set", true);
 
-  document.getElementById("cookie-banner").style.display = "none";
+  const banner = document.getElementById("cookie-banner");
+
+  if (banner) banner.style.display = "none";
 }
 
 function getCookiePreferences() {

--- a/src/cookies/checkCookiePolicy.js
+++ b/src/cookies/checkCookiePolicy.js
@@ -34,6 +34,16 @@ function isCategoryAllowed(category) {
   return policy[category];
 }
 
+function setCategoryAllowed(category, value) {
+  const policy = getCookiePreferences();
+
+  if (!Object.keys(policy).includes(category)) return;
+
+  const amendedPolicy = Object.assign({}, policy, { [category]: value });
+
+  setCookiePreferences(amendedPolicy);
+}
+
 function setCookie(cookieName, cookieValue) {
   const category = getCookieCategory(cookieName);
   const isDev = window.location.hostname === "localhost";
@@ -110,5 +120,6 @@ function checkCookiePolicy() {
 
 module.exports = {
   checkCookiePolicy,
-  isCategoryAllowed
+  isCategoryAllowed,
+  setCategoryAllowed
 };


### PR DESCRIPTION
Expose the new `setCategoryAllowed(categoryName, isAllowed)` which does what it says on the tin. This will be used by the Product Pages to record any amendments to our users's cookies preferences.