### PR TITLE
Fix/cookies path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Frontend functionality shared by the GovWifi websites",
   "main": "dist/govwifi-shared-frontend.js",
   "files": [

--- a/src/cookies/checkCookiePolicy.js
+++ b/src/cookies/checkCookiePolicy.js
@@ -51,7 +51,7 @@ function setCookie(cookieName, cookieValue) {
   if (isCategoryAllowed(category)) {
     Cookies.set(cookieName, cookieValue, {
       expires: 365,
-      path: "",
+      path: "/",
       domain: isDev ? undefined : BASE_DOMAIN
     });
   } else {


### PR DESCRIPTION
# Description
We don't want to use a blank path, enforcing `/` makes more sense.