### PR TITLE
BAU: Add secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,2355 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-11-13T16:59:37Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "package-lock.json": [
+      {
+        "hashed_secret": "fd59e8e882cf3aa4f999d0843227e0bf007007fb",
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0a76474db59cc4d0130dcb69ac72efa727a1df10",
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "acdedaa37af9ffc6e1df202ebe975fb7d1a7e956",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bb69dcb471a9bdb81b13fc49e6f101c1f0eed105",
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e1b883c98cb994942b69775bc78907734ad0ec3e",
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "de6fdb8e50600c6316cfe1fb3ca52b311d2ab3d8",
+        "is_verified": false,
+        "line_number": 48,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d6d0803ef305884238f70ed7a6a687b1bf3f821d",
+        "is_verified": false,
+        "line_number": 54,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2fddccdc9e1bd2082fa9707da1fe700616b9658a",
+        "is_verified": false,
+        "line_number": 63,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ea76384af2f929ce6d0ab2b2d05704570ed43173",
+        "is_verified": false,
+        "line_number": 69,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "727cb49b2dd2086b01a48ec701bf534a3754c123",
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a441bc59668f3617d53f68316067734f1ca15c9e",
+        "is_verified": false,
+        "line_number": 90,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f24bd2751af4b837efa4d057b22cff780197a421",
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4a5ed42b44110c2242e70739c0cd0e6d9688ba38",
+        "is_verified": false,
+        "line_number": 105,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e5fa65f98ab9792685976a03b588fb14ab03f734",
+        "is_verified": false,
+        "line_number": 121,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "44f6556b600cc03762db8f5de370ef49da7d2a00",
+        "is_verified": false,
+        "line_number": 134,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b532db65a8497dff69d483432ab13a58390e4ec3",
+        "is_verified": false,
+        "line_number": 146,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "90f57d1a5149e140cb88b85c83571292d4d2295e",
+        "is_verified": false,
+        "line_number": 160,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5880ddbdbc44c06d6ced7bda8f43aebd5777328c",
+        "is_verified": false,
+        "line_number": 174,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "cfda2bfd1e4e1c53f7d5ef7ca821f891918b55c9",
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f42fe8ad4090aa5b3f9997d80fbe0176037f2ed9",
+        "is_verified": false,
+        "line_number": 191,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ce9ed4704ec7264ace51562fe8781a32814dc1ea",
+        "is_verified": false,
+        "line_number": 197,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "84b662fc9a2a275f90d0afafe6ce08a4d0928ac8",
+        "is_verified": false,
+        "line_number": 203,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "59dc224f5be3f733d5e56b9b4d083bd513e2b461",
+        "is_verified": false,
+        "line_number": 215,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ac0633cd592596082f5e608c4250b7600b38b3b3",
+        "is_verified": false,
+        "line_number": 221,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b9509cb72e127330340c248f2e104ef2d55fbf0d",
+        "is_verified": false,
+        "line_number": 227,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ed5695eb040e5c940801b8d72eb96490e4b2f11e",
+        "is_verified": false,
+        "line_number": 233,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "95ed365fab719053e85eada773292d5aca40e8c3",
+        "is_verified": false,
+        "line_number": 242,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "afcd43c83599fb9d4f180692c01ff53ddc76b456",
+        "is_verified": false,
+        "line_number": 253,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "72be827197c7f8736230b9148b47fa771dadf6fd",
+        "is_verified": false,
+        "line_number": 259,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "12e16631572990b5dee1aaa97375a0df8bbfcb0d",
+        "is_verified": false,
+        "line_number": 265,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0fa9d47340e004c22e01efe83a5783dd19e2595f",
+        "is_verified": false,
+        "line_number": 271,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3a361674feb63bcea68c09136ca4e4d68fd66be5",
+        "is_verified": false,
+        "line_number": 277,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "69e896fe5a9d32fc66f45f5a1337dda8702f3dc6",
+        "is_verified": false,
+        "line_number": 283,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8373744a5c2990954ec7007cacd6ae38b1720d9e",
+        "is_verified": false,
+        "line_number": 302,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "18724945e4b3e06cc511ede7678ca2d29f8fcd54",
+        "is_verified": false,
+        "line_number": 318,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "465e6db83eb15ab07e908c9acff9a4e9dcb979f0",
+        "is_verified": false,
+        "line_number": 329,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "309846a058bc82805b31604354e253ca4a2c37f0",
+        "is_verified": false,
+        "line_number": 335,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c13ec9b3477b888fd702fb1919dfad029c0e40e2",
+        "is_verified": false,
+        "line_number": 342,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "456d02ad0d4d84a2516934ac4cd212b702a35971",
+        "is_verified": false,
+        "line_number": 348,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ca8c878c94ee4c7eba295e1fd42cc3c0d7a27136",
+        "is_verified": false,
+        "line_number": 354,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "92b56edda4f2906f548fe77c015490e6ba2ee4c3",
+        "is_verified": false,
+        "line_number": 409,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d54e03e6cdd359af7ee4a154c913e011aec89c0b",
+        "is_verified": false,
+        "line_number": 415,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "62fb28ac290866ddcecb8d0a108f604eae09d90f",
+        "is_verified": false,
+        "line_number": 421,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d628a4cb9e9bc87d6d920449895fb8456c8cb253",
+        "is_verified": false,
+        "line_number": 428,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e2f8ed204b081d28612cca592b04d252763cfd43",
+        "is_verified": false,
+        "line_number": 438,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "afa7c1da8285c6156db39a507b912b53e5bd8038",
+        "is_verified": false,
+        "line_number": 444,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3aafb400e42871c4a994eba8013e4ff1034c2724",
+        "is_verified": false,
+        "line_number": 450,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "37f10901fe39f2bd7e3803f1aa0a5f8c4f56d16c",
+        "is_verified": false,
+        "line_number": 460,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ddd7d1f42e0cb039593dc17205d77b6ec6b7e969",
+        "is_verified": false,
+        "line_number": 489,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "01638373be457b561d49a7e0e54dca7bcb85ae95",
+        "is_verified": false,
+        "line_number": 495,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "00ae2fafcf6da74240bf6738b977669777a73f92",
+        "is_verified": false,
+        "line_number": 509,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "61e8ad2210eaf9544809547512563b4175ef8592",
+        "is_verified": false,
+        "line_number": 520,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7413a46e5eeb26ae35de573d7b1447d6c61f9832",
+        "is_verified": false,
+        "line_number": 532,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bb4dfc74f737912ea7c98f86f137352e1fc48ccf",
+        "is_verified": false,
+        "line_number": 550,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0b86d5ba5a4c07a2ae3b6c3b49e0a40565b12232",
+        "is_verified": false,
+        "line_number": 586,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0512e37fbedf1d16828680a038a241b4780a5c04",
+        "is_verified": false,
+        "line_number": 595,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7d9cd3243acfca649da3f02815907f3c86e33d62",
+        "is_verified": false,
+        "line_number": 606,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "975bfe4f343880d273a2f53c57d6679440fb63c4",
+        "is_verified": false,
+        "line_number": 612,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "791364d52a19c32676d5dc49724e2abb51940ad1",
+        "is_verified": false,
+        "line_number": 618,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "79077b53b205dc3cfe1ab7f5c7315fb0af30bc1a",
+        "is_verified": false,
+        "line_number": 624,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "38a38829abe9a457725a648afcbc3130eb9886c0",
+        "is_verified": false,
+        "line_number": 647,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "da303c9fbfb94b016d8ae8953ad15fca74877107",
+        "is_verified": false,
+        "line_number": 664,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "accd3d42ae3e5a54f5c871a2c507ec4d5955911f",
+        "is_verified": false,
+        "line_number": 674,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bb05672f29d196996d896664a1b8ab1d5b96fe4d",
+        "is_verified": false,
+        "line_number": 680,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8368db68b0ace9e898989e5e645c5e1eddf99b11",
+        "is_verified": false,
+        "line_number": 691,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9e7f4d9b4aa5d5bf5c714bf2bb38a4ff74dacf7e",
+        "is_verified": false,
+        "line_number": 702,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d61249f34437705a28fb8b6097dc589a6bfc96a0",
+        "is_verified": false,
+        "line_number": 719,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2072834961e980f104f7a8f7af4d97aed97811f5",
+        "is_verified": false,
+        "line_number": 729,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8f95bdf43361cffe6720264f402b5636239f6367",
+        "is_verified": false,
+        "line_number": 739,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "36a41bfa336a40f390233bcb3edba75b423c0ac5",
+        "is_verified": false,
+        "line_number": 746,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b876eadc4946ae55efa33b36bef38d9c6dbc5c98",
+        "is_verified": false,
+        "line_number": 758,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "678b531544f1af715c200ab4139560e58152939b",
+        "is_verified": false,
+        "line_number": 764,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e548fac3f40519f019a82b3866e7d119b6f68293",
+        "is_verified": false,
+        "line_number": 773,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "126b1a28a866b1c07b5e59a68f759c79b6d4103a",
+        "is_verified": false,
+        "line_number": 783,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dd8af511bc464f9a800f847a1dddbe1c34d816d0",
+        "is_verified": false,
+        "line_number": 806,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a95bb8b89cb19b52b0e3daf60968510522824707",
+        "is_verified": false,
+        "line_number": 823,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "425facb0263585640281594e576f8b79b82d48aa",
+        "is_verified": false,
+        "line_number": 834,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3da27985279d7d55ced598655b77d5a3aef28e39",
+        "is_verified": false,
+        "line_number": 844,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "df911743057e957d166c09e0746e85bf596195d6",
+        "is_verified": false,
+        "line_number": 859,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8f2d13e4f45ae4895bfd83f17e0f27556e4870a2",
+        "is_verified": false,
+        "line_number": 865,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4cfcfce29718cd8a83f4d86020d252153380a3df",
+        "is_verified": false,
+        "line_number": 871,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "26f76deebe03d118284ce3a2b105ef284a3af65b",
+        "is_verified": false,
+        "line_number": 877,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "06884be634acb9ff16562ab93522093244b75a4e",
+        "is_verified": false,
+        "line_number": 883,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a7a60b774aaf0f568775271103de1ae725ee0a3b",
+        "is_verified": false,
+        "line_number": 895,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "65bb373bd77c0ef65ee9d5d0bb53f1051d12ae7e",
+        "is_verified": false,
+        "line_number": 901,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f30776ced70d3653e0f391ac57e275c62d16944f",
+        "is_verified": false,
+        "line_number": 907,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3e7b57aa814dbdac1ca5971ed1c395b5dfe1de3b",
+        "is_verified": false,
+        "line_number": 933,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "383ad5d54e78fe5cb70d40da2b5d07a815d1c106",
+        "is_verified": false,
+        "line_number": 951,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "cdf7a2242ebfe015517df88b6cfd4c76573dbc19",
+        "is_verified": false,
+        "line_number": 964,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c8cd52c3cac611b968d949d507c35c91ff317291",
+        "is_verified": false,
+        "line_number": 978,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a19dcad6eeb13918841a7fedacdf027e79906b37",
+        "is_verified": false,
+        "line_number": 991,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8e948a3b773d1a2e4b6f4220216efa734315246d",
+        "is_verified": false,
+        "line_number": 1016,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7d6c45d0c459f7efb2978ac36c219a40cbeac40f",
+        "is_verified": false,
+        "line_number": 1025,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f7efa873e3aef8651e0fa5414e6a95e8ac40b2e4",
+        "is_verified": false,
+        "line_number": 1037,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dbf8c30ce34e1e125fde3a8f871da855aec1ac1b",
+        "is_verified": false,
+        "line_number": 1078,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "57c660c5e1b05af3e5f4289afd5601a032cbcfc7",
+        "is_verified": false,
+        "line_number": 1088,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3d749c4452db3f6c24bb98d20698351614a81d60",
+        "is_verified": false,
+        "line_number": 1094,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b00b535475f87f2b2aa8c2d9ce75ed1b60e3c64c",
+        "is_verified": false,
+        "line_number": 1113,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dead9d741c2b9d7a57d1c0c5a4ea0aa2a1d8f402",
+        "is_verified": false,
+        "line_number": 1123,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5096ddf3507254b9a2f914ee3366cf271cb32bc9",
+        "is_verified": false,
+        "line_number": 1129,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "90172302531cad4f65ad330bd1b784e5a3e140b8",
+        "is_verified": false,
+        "line_number": 1135,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e84aa52424ed60e8833a64a5797581ae16673fdf",
+        "is_verified": false,
+        "line_number": 1144,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2388ab43f5bddb12d6eabfd0ef9bafe89829f18e",
+        "is_verified": false,
+        "line_number": 1155,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b0eb24453b6ad7c475f1990a000dec31262d36b0",
+        "is_verified": false,
+        "line_number": 1165,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ed3996133a461aa126edf4caf4a038df1b8e0632",
+        "is_verified": false,
+        "line_number": 1177,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "66c266c0d855a855c0ab73bd5386af0c3083e291",
+        "is_verified": false,
+        "line_number": 1200,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "922fbb900f0729856770231142a74c8ad632ef8a",
+        "is_verified": false,
+        "line_number": 1206,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "796925256bc0f4dc43cdfab7fbff852eace18f42",
+        "is_verified": false,
+        "line_number": 1212,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fb6ccc34019525f5c9502ce7c302b16040702450",
+        "is_verified": false,
+        "line_number": 1221,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "12379b4bb7a891e5ff6be443b07c8c62a9691017",
+        "is_verified": false,
+        "line_number": 1232,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ce73fd58ec575a8a778d31db1ad298dd5123f48e",
+        "is_verified": false,
+        "line_number": 1244,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dc79c293824667a1965d4136b3615840c57e2990",
+        "is_verified": false,
+        "line_number": 1250,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "afca0b380a66cc359f66a3e2b1c00103a9b5807d",
+        "is_verified": false,
+        "line_number": 1259,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "595bf5444be01662404d8b33e63098866a691bf7",
+        "is_verified": false,
+        "line_number": 1265,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dd0576769bb1c8372e84625de5b22b85cda1e68a",
+        "is_verified": false,
+        "line_number": 1275,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8391286cc1bda9f5510e294af9545020bed4e1df",
+        "is_verified": false,
+        "line_number": 1284,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "865a8108fc3bc7f86527f9ac5b6dfc0cded15565",
+        "is_verified": false,
+        "line_number": 1290,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1b2b3fb2bfee2f764389bd52df0cf743ece4e37c",
+        "is_verified": false,
+        "line_number": 1296,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0fd9a27b38d94a9d674b1fccc47f3b6a2f61e5e3",
+        "is_verified": false,
+        "line_number": 1306,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "615e8d3115abdde709b5cc35388689fc4f32b35d",
+        "is_verified": false,
+        "line_number": 1321,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3937ac1b11e97055d2054a588e474d9f427016d1",
+        "is_verified": false,
+        "line_number": 1356,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "074d2d7d52da9b568c3b6f4a91ad2d7f76ebdca9",
+        "is_verified": false,
+        "line_number": 1386,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8e71b7828c7c554f05dbbabddd63301b5fc56771",
+        "is_verified": false,
+        "line_number": 1451,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fea0d9c5b0c53c41e6a0a961a49cccc170847120",
+        "is_verified": false,
+        "line_number": 1457,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "08deea224d989a6f2fbaa1bde72798299f13f804",
+        "is_verified": false,
+        "line_number": 1463,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "47ea40b8e5df6783598df509aa331f2adaed2818",
+        "is_verified": false,
+        "line_number": 1469,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1579e4a51b8205a9daf8654833719725016ee263",
+        "is_verified": false,
+        "line_number": 1476,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2efc699bfdd6552c88b8e017ba744cca344ba649",
+        "is_verified": false,
+        "line_number": 1499,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "65a4d795322442bf629c11a854d57ccd2291360f",
+        "is_verified": false,
+        "line_number": 1510,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3eb6ad2b9b202cf26892b30ad34cc0e3213c5790",
+        "is_verified": false,
+        "line_number": 1519,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f8dea6345b6866c7bcaef205110c797e1d0282fe",
+        "is_verified": false,
+        "line_number": 1531,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1709a1e80bdd033be3e725fc2496d16353bf799b",
+        "is_verified": false,
+        "line_number": 1541,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f0039581bad4dbd1e949839ec456796794a2c388",
+        "is_verified": false,
+        "line_number": 1547,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d15385db5810db2d2e30911e71b6a8fba28f010a",
+        "is_verified": false,
+        "line_number": 1556,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "12ffe31fe2cdc41991054eec09b2a8e1105b126e",
+        "is_verified": false,
+        "line_number": 1578,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "014ad66380114b04d5f25b14f1d81f1f323c9c1f",
+        "is_verified": false,
+        "line_number": 1584,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "184476d985c0d799b82544165cb4d456129f594c",
+        "is_verified": false,
+        "line_number": 1591,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "aea8f7ae787ad25f04c232d2f01917f4ff7d154c",
+        "is_verified": false,
+        "line_number": 1597,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8bdb30b7ed09eedcf47b125ec7fc0646e8bc2018",
+        "is_verified": false,
+        "line_number": 1606,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8f337304c5ed78319bc8d7e60dd0f3753fdd0407",
+        "is_verified": false,
+        "line_number": 1612,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e0dae239525c249bce47a07a112019487fb0e932",
+        "is_verified": false,
+        "line_number": 1626,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b489460f86da8364ede2aac2f391d28ab21cb155",
+        "is_verified": false,
+        "line_number": 1636,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1f03f720d65aaa062329fe919afbd25bcb546b0b",
+        "is_verified": false,
+        "line_number": 1645,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3c9fef30e43f43278daa4509961eab33bef749a0",
+        "is_verified": false,
+        "line_number": 1658,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "74843735ef6efa4c111172f25c69f3172832f367",
+        "is_verified": false,
+        "line_number": 1671,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3de084e244b8cee5e85a65912415cc90ea37b393",
+        "is_verified": false,
+        "line_number": 1677,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "88d7d85b259e7a3efb48103991f646fd730ae63d",
+        "is_verified": false,
+        "line_number": 1683,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4f71afb37599e5e5e33cbc2a3b36c8e78ec89764",
+        "is_verified": false,
+        "line_number": 1694,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a871a431e45997ad51f47ae83f66513d05fe7d31",
+        "is_verified": false,
+        "line_number": 1715,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1de4b381561818ad66ea4942451e0df440649f1d",
+        "is_verified": false,
+        "line_number": 1726,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dab00d860d09dd9092b16718edd82bb24a6a21e9",
+        "is_verified": false,
+        "line_number": 1737,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a754fe92d61445d02e447178756ddbea48d9c355",
+        "is_verified": false,
+        "line_number": 1745,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5c6f1612652c11273f6dc6ed43f6d3f39a8ee5b7",
+        "is_verified": false,
+        "line_number": 1755,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d2306a21994eefb44d055e593477d8c194e2acab",
+        "is_verified": false,
+        "line_number": 1772,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2985b094dfe3d948423800b3e5f0c2c7e1c2dbf3",
+        "is_verified": false,
+        "line_number": 1775,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "e57b29963519ec78c5f35ed58105121912c9f539",
+        "is_verified": false,
+        "line_number": 1781,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7e49eae03cfac1c21f012fd6aa098265f24fadfa",
+        "is_verified": false,
+        "line_number": 1794,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7b99c66903998b2ed25e095decbbad0011c5556b",
+        "is_verified": false,
+        "line_number": 1803,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "081139174c9a87b176f41739ab3151f50bad37b0",
+        "is_verified": false,
+        "line_number": 1814,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f463626da4752feb50c0004ec76fdc4fb73dc8ed",
+        "is_verified": false,
+        "line_number": 1826,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "14f7b9701b0db90fc803d73c82e43a4d7f457065",
+        "is_verified": false,
+        "line_number": 1841,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b9e08549f6126c10edea733e6dae3ce2ccde3d35",
+        "is_verified": false,
+        "line_number": 1849,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9f0378dc9daac1ce3866ffa4dbdb48d3a3cf5ad1",
+        "is_verified": false,
+        "line_number": 1861,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "209bf9cfe9000c6851cd4f94165d30ee1cd3dca1",
+        "is_verified": false,
+        "line_number": 1867,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "399df148c825f082884b1d83b7e6863885965215",
+        "is_verified": false,
+        "line_number": 1873,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8bb8612c3ddc6157d7acbeab26c59d7bd078237b",
+        "is_verified": false,
+        "line_number": 1879,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "617178846b2e54138f8be21e8a9d06ac21b3fb7e",
+        "is_verified": false,
+        "line_number": 1895,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "cf09cb791688fe019284bfdc362abc41918645a5",
+        "is_verified": false,
+        "line_number": 1911,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "326aa0fbb5de3f8f869c844e7d1266db58fb80f1",
+        "is_verified": false,
+        "line_number": 1917,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8c9218c6ee579a9b92aed159504550e471508dc6",
+        "is_verified": false,
+        "line_number": 1923,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "afd3e522e507fac3fb853d6e8d324863594cc16b",
+        "is_verified": false,
+        "line_number": 1929,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0ff23531244520eda89e25f3904a3ef1da82dbda",
+        "is_verified": false,
+        "line_number": 1935,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3c22fe71719555d5e4c508c724ee1c9a9728d8a1",
+        "is_verified": false,
+        "line_number": 1955,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f8cd5b7823a4fade2a941a82fc76a264f2c3cc6b",
+        "is_verified": false,
+        "line_number": 1965,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a486ed705e61117f11af935a9d07da1a6f9e59cd",
+        "is_verified": false,
+        "line_number": 1971,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "984ea37e5caef89b016b5b5fd7a6a5ccd4c3c6a5",
+        "is_verified": false,
+        "line_number": 1991,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4500f30aa9a2cae89bbaf1b21deab21cdf8c0e60",
+        "is_verified": false,
+        "line_number": 2002,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d1fe817182a7be7a143c2f92181ef330dd525790",
+        "is_verified": false,
+        "line_number": 2010,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b7f8937f7821d03786e13293e0d0482c51adbf7a",
+        "is_verified": false,
+        "line_number": 2016,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7bc2a29249d4c79d00152e6b7e23f1bad50ee72d",
+        "is_verified": false,
+        "line_number": 2022,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "36772b0a4de160ad3eec470df23d92655268e759",
+        "is_verified": false,
+        "line_number": 2028,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1f587e0f3bef604761b68a68223d82500d8c5860",
+        "is_verified": false,
+        "line_number": 2037,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4df4460648bf5d051f1a9ba9142c3fcb6d5251af",
+        "is_verified": false,
+        "line_number": 2057,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "51f1d8a64e7cab12b96f79fc3dd2816968b9a8e9",
+        "is_verified": false,
+        "line_number": 2066,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "02caf1c0c7c1e839b9b3b85fa41701a1d38c679b",
+        "is_verified": false,
+        "line_number": 2072,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "aef96b0a0303c99c0bedbe165cca1bd53b72a599",
+        "is_verified": false,
+        "line_number": 2078,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "80d73b6f7e87f07e3ae70ef1e692aa9569574551",
+        "is_verified": false,
+        "line_number": 2084,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f997f480531d137b87109bf8879332b9a7f27b12",
+        "is_verified": false,
+        "line_number": 2090,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5e1ef5987552ffcce5eab6ac6d4f8d20a07c5188",
+        "is_verified": false,
+        "line_number": 2096,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ac548abcd1068f5e2935b00f6876f3fd8496dcf1",
+        "is_verified": false,
+        "line_number": 2102,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "476b425c942e47f41faab5adfc309c06e8ee0612",
+        "is_verified": false,
+        "line_number": 2107,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "127f92724797904fb4e6de2dfff2c71c07739612",
+        "is_verified": false,
+        "line_number": 2113,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5a18025c758325837667dfe289b46b4a52ff74ec",
+        "is_verified": false,
+        "line_number": 2119,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "482661ab1a2dd1c3df1ac35182dea446441301d2",
+        "is_verified": false,
+        "line_number": 2128,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6652233b1ddaced0a85832b0c5f083bf93a9055a",
+        "is_verified": false,
+        "line_number": 2134,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "555008b30c5c0f948abe11f265423d6041aec959",
+        "is_verified": false,
+        "line_number": 2143,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "281ab5a28a1be6a8b3b9d892620b5420fc3cb2a8",
+        "is_verified": false,
+        "line_number": 2149,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3481f833eaf3f743059d867aae73e7309f592359",
+        "is_verified": false,
+        "line_number": 2160,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "39c90ef413b8d87ad2962e32e903265838509836",
+        "is_verified": false,
+        "line_number": 2170,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7ed5906c17ddd4e8330c8475dac722175e5e67c4",
+        "is_verified": false,
+        "line_number": 2179,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5d37b4585fc2daeb632909d964bc11cef5e57e3e",
+        "is_verified": false,
+        "line_number": 2188,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "126c3daa58f2a78d33a0d0eabe4626340ef1849f",
+        "is_verified": false,
+        "line_number": 2198,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "abfa3059fcb1e7273332d93c5c752e3cd52a7296",
+        "is_verified": false,
+        "line_number": 2207,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "eeef9d425ceced7dee7dab3081968b79afa80565",
+        "is_verified": false,
+        "line_number": 2213,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0a2987896ed4ef59e386276b69e428149f47abf6",
+        "is_verified": false,
+        "line_number": 2222,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bba46e8ef3330d19d4a3ac910db8668ad9c3ca53",
+        "is_verified": false,
+        "line_number": 2233,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "15ab34c532aff3044dcf9fe09ed8bd8e18e5e11f",
+        "is_verified": false,
+        "line_number": 2244,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "32c6700140fee1302907adc5e0a301858ac60594",
+        "is_verified": false,
+        "line_number": 2254,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a6a389d7afb0354ea546413b86cd3e3490ea70e0",
+        "is_verified": false,
+        "line_number": 2275,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0913ac5bef0b5ee1e0619deee04bed578b2cb11a",
+        "is_verified": false,
+        "line_number": 2293,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "11d7b97225d3393a9d1426e4b58b46745e91084c",
+        "is_verified": false,
+        "line_number": 2299,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bc4bdbf7b24369e8a9cd18be139c43c72534e8c6",
+        "is_verified": false,
+        "line_number": 2305,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "67619a42987e368dd3fe59582e4e13c12e7a563d",
+        "is_verified": false,
+        "line_number": 2311,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "23e42656fba130d56c20abddb94b6b7bfcad69a8",
+        "is_verified": false,
+        "line_number": 2320,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ea0c4e44ffdceb27bc8504df71bed14430e5e18e",
+        "is_verified": false,
+        "line_number": 2326,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "917137d0d13602cc84d8db8aef6f6c56a7cc7907",
+        "is_verified": false,
+        "line_number": 2344,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "29b0281ecf7853ac202cc87ea746d71d091e7340",
+        "is_verified": false,
+        "line_number": 2354,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d208a8d2ee01ca62f09802c275315818f647735b",
+        "is_verified": false,
+        "line_number": 2365,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d98e8ec34d294406f3f1e853a356ada1b4419b92",
+        "is_verified": false,
+        "line_number": 2374,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f883f0bd87d8455814f491e2067bd3f62454c7c2",
+        "is_verified": false,
+        "line_number": 2388,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f99039bf6e12ab1c145a15cb3c0dc95854023457",
+        "is_verified": false,
+        "line_number": 2394,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "12986f935c4f67ef2719f2c0d33d6ed9168d4fb0",
+        "is_verified": false,
+        "line_number": 2401,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d8804d9cc71f687821d608a8c1c9f851df168128",
+        "is_verified": false,
+        "line_number": 2420,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e6ec6fee466f0903de2a9307687cfb4a36312ceb",
+        "is_verified": false,
+        "line_number": 2426,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "717cf11e0c3d70eec7e1ce8e41ba13a8730984d1",
+        "is_verified": false,
+        "line_number": 2432,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "89f0df6c925a94f6b907e787ea49a5bde5b1294e",
+        "is_verified": false,
+        "line_number": 2442,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0a68e003e521d8b996e1c07b3b5b2664de31fa44",
+        "is_verified": false,
+        "line_number": 2481,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b9a549991528b1f793bc9b74a0a43af994f93dab",
+        "is_verified": false,
+        "line_number": 2497,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f99bc28b108e16abbbb899272cd4be7b0257c146",
+        "is_verified": false,
+        "line_number": 2503,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "34a8de83fea84051a0d78af5c1f5a6b79edcf676",
+        "is_verified": false,
+        "line_number": 2534,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "654fc8c7b786aead53e3209b820a651a7eccc894",
+        "is_verified": false,
+        "line_number": 2543,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a9a887079e3f42fe43e569ebeaa89a68020adf0b",
+        "is_verified": false,
+        "line_number": 2561,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "44ee730d8a77c25088e7ef389739e035ccc5a34e",
+        "is_verified": false,
+        "line_number": 2567,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "061ef72cc8dca7a140e7ccdf2459eca73656cd53",
+        "is_verified": false,
+        "line_number": 2578,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d0a953de593a0a7b26b925a6476d8382cd31cb0e",
+        "is_verified": false,
+        "line_number": 2584,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2a23be1fc1366fa8795a699621b47ede13296ec5",
+        "is_verified": false,
+        "line_number": 2590,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b2e846b4c4f9b16738215a08bb6838b125977d28",
+        "is_verified": false,
+        "line_number": 2596,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c1b9dbe2a4a51543303a341f2f352218d38daf55",
+        "is_verified": false,
+        "line_number": 2605,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c9a0f70271023a1b82d44b6544c32f834098c007",
+        "is_verified": false,
+        "line_number": 2614,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "44182573c46aa28c876332d2f480bf82ce5fc237",
+        "is_verified": false,
+        "line_number": 2620,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "41bf74e2a1e101e57c232851b908fec09a166296",
+        "is_verified": false,
+        "line_number": 2626,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dd294329d1e80f97bef3af3dd874d202542cc91c",
+        "is_verified": false,
+        "line_number": 2637,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "34119d5ceca3d5e844fad3cb660848edb58fd598",
+        "is_verified": false,
+        "line_number": 2647,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6c651d6ac18f7e9a1f94e1bc2f68379cc1851432",
+        "is_verified": false,
+        "line_number": 2661,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e3bb1bc5f65dafa45f3ba09e91257945e0d7e3b6",
+        "is_verified": false,
+        "line_number": 2667,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2115ca209d12edb338c4f40fb760e8267dc6ce58",
+        "is_verified": false,
+        "line_number": 2673,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0064a8ba9f575307cb1474d4fc0801fb52168798",
+        "is_verified": false,
+        "line_number": 2683,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bf7bb1d2cc63d8c18f6969743216218a6a7052d8",
+        "is_verified": false,
+        "line_number": 2689,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d998975007ed66c92c3c11c211fb7dfc1332d2b2",
+        "is_verified": false,
+        "line_number": 2695,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d972c490290fb0e7256745d754a8a5fe4a4ea889",
+        "is_verified": false,
+        "line_number": 2702,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "891e23c02f7af11c912b47e84dba9ebc2a810571",
+        "is_verified": false,
+        "line_number": 2708,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d131113d388bde851a3193899fdd3c57b2377c4a",
+        "is_verified": false,
+        "line_number": 2720,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f8046f516aa68073cde0098865e351b75d301a91",
+        "is_verified": false,
+        "line_number": 2733,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bfd1af02b701e91707a7425bba100d60beef3ffd",
+        "is_verified": false,
+        "line_number": 2740,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "faa5ddb11d191388de27b87ec41c589382a189d9",
+        "is_verified": false,
+        "line_number": 2746,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dd908d580dea50a39aee357c457d50382aedfa5d",
+        "is_verified": false,
+        "line_number": 2755,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c23b0650f6cba3e66097d40e2f3fc3e62c5ab213",
+        "is_verified": false,
+        "line_number": 2761,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bc98c415b1c6ee93adf8e97a4a536b6342337c19",
+        "is_verified": false,
+        "line_number": 2767,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "22ea208c4ba0fcdfc5a69a1af117e5795547889b",
+        "is_verified": false,
+        "line_number": 2773,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "dd5ea12fc9e7e04ed77e6035faf82e6038d74874",
+        "is_verified": false,
+        "line_number": 2779,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "322bf281c143dd913bcd251730e5664ba4d060dc",
+        "is_verified": false,
+        "line_number": 2785,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8567e2f5761218b6cdb489cf94623c3e253005a1",
+        "is_verified": false,
+        "line_number": 2799,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "47709a15a1b02a87f65dfcd5f3e78e0d2206c95f",
+        "is_verified": false,
+        "line_number": 2807,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e13d15026e10d70b13b2ea0cc5cfd75e878dde25",
+        "is_verified": false,
+        "line_number": 2817,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "53ae304aa320071d1a4a55e10873c6c93182b66c",
+        "is_verified": false,
+        "line_number": 2828,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7a87fb248397359e9c6ca6e46f39805789059102",
+        "is_verified": false,
+        "line_number": 2840,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "51f38b23af543da8b637a3bd62f5fb2c460e3b3d",
+        "is_verified": false,
+        "line_number": 2846,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "1c3aa8b2d64e707bcfb9c379d6ad7806b33f057b",
+        "is_verified": false,
+        "line_number": 2852,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a215faa77ef3f0cca4574804353e1df8298bdd49",
+        "is_verified": false,
+        "line_number": 2858,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "769b14cd5181d229420ba64a2e63b4d860e8e2dd",
+        "is_verified": false,
+        "line_number": 2867,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "922ac7db4914c20910496a41c474631928d6c2f2",
+        "is_verified": false,
+        "line_number": 2877,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "80faa7bbaf9bdd773e5fc25e72ad2f8ee4d62966",
+        "is_verified": false,
+        "line_number": 2892,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "860fcf5757e6150d3e9a5c57ebfa295249c14ca2",
+        "is_verified": false,
+        "line_number": 2902,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "89d8aced3b58cd50ed12b27ddbf2d50b3ae73cd6",
+        "is_verified": false,
+        "line_number": 2912,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "efed46e08f84c2eef193a9c6b4fbde920ac398b6",
+        "is_verified": false,
+        "line_number": 2918,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a26cca26377963bf476a9569a2eda006aa2029a1",
+        "is_verified": false,
+        "line_number": 2925,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "42ebd78fb439ca877b78cdb91475a135102957c8",
+        "is_verified": false,
+        "line_number": 2937,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bea46b2b95add66abfaccce2da1e5de886694fb5",
+        "is_verified": false,
+        "line_number": 2943,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e51858b4ffe52d0ee0f5457e387f441e33bb902a",
+        "is_verified": false,
+        "line_number": 2949,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "34bb77b8a0b8fdb1787d549b64895ee00f52184a",
+        "is_verified": false,
+        "line_number": 2958,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "95631761acb6ffe366cd95710b517dabfd6537e6",
+        "is_verified": false,
+        "line_number": 2968,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7d1dc0d925a7edb3991d6edcbbe2e5b27e28ce79",
+        "is_verified": false,
+        "line_number": 2981,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2f4918b0727ac9d23d93b3cfd126f6d76029220b",
+        "is_verified": false,
+        "line_number": 2987,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bbab745643f5fee02b35f58e5c77f75a7f362878",
+        "is_verified": false,
+        "line_number": 2993,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "61fe73786601f140670a91202612ceb7c5baa2d6",
+        "is_verified": false,
+        "line_number": 2999,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e53e963b78b9c0f691f1b2f766821777276e5688",
+        "is_verified": false,
+        "line_number": 3008,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5b467d9510fe899209822592a777c68376fc4535",
+        "is_verified": false,
+        "line_number": 3018,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d5e822897b1f37e6ce1a864e2ba9af8f9bfc5539",
+        "is_verified": false,
+        "line_number": 3027,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "66738c11f9d5e6983c368e3d81c4971a7ff954fa",
+        "is_verified": false,
+        "line_number": 3033,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b3b27b30ed68fdff4940788f524b1271d0f6225d",
+        "is_verified": false,
+        "line_number": 3042,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "756444bea4ea3d67844d8ddf58ad32356e9c2430",
+        "is_verified": false,
+        "line_number": 3053,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "20e12f685b2bebd9a0799ee9421dc2479ed716ab",
+        "is_verified": false,
+        "line_number": 3059,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6e22f3ee54a6729d0ab5aa692a26551beca43f3d",
+        "is_verified": false,
+        "line_number": 3068,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "cec27128c05840dfd3d1099a8c249be68b0f8624",
+        "is_verified": false,
+        "line_number": 3074,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5941a94cb67be706b00000babf04e70bdec7f631",
+        "is_verified": false,
+        "line_number": 3097,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "82736b678344a93d87cea3f5390393684835c6f6",
+        "is_verified": false,
+        "line_number": 3103,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bcb0a064a9b6f856935b5375646d8de97b234dbf",
+        "is_verified": false,
+        "line_number": 3113,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5bf17c4375713f640d891ea4628897bdd7fe4e85",
+        "is_verified": false,
+        "line_number": 3122,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fcf56df838316b9be4013f8954fd3aff8f916599",
+        "is_verified": false,
+        "line_number": 3128,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fdf983219faffd2e867aca8f18cd4eb2f80e7ce5",
+        "is_verified": false,
+        "line_number": 3134,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "682d7df97735b0c73fae4b25f6e41f55d2b50fcd",
+        "is_verified": false,
+        "line_number": 3170,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ab4e31ac4e5a7eb1234483a25434a6074922710c",
+        "is_verified": false,
+        "line_number": 3181,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b0db0c739490f770b2db61370a98044a02d5d6e1",
+        "is_verified": false,
+        "line_number": 3190,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b43ca1e10e12f78e640432481609358f55383d08",
+        "is_verified": false,
+        "line_number": 3199,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "84a5507f6d48cbf4f25c71f66d03b0767d0fea91",
+        "is_verified": false,
+        "line_number": 3208,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "754bf1b7e5e4b89660f03b2660a094b671e3e404",
+        "is_verified": false,
+        "line_number": 3221,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e816cb4e453d42df774ed9a82f9b0d91cd118b3c",
+        "is_verified": false,
+        "line_number": 3241,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9fda10771117cd0838110f9ecf461dd956fa92fc",
+        "is_verified": false,
+        "line_number": 3247,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e995ed7583972dc92617265ea52311fcb188a518",
+        "is_verified": false,
+        "line_number": 3253,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6c307e5c1141162267b3cf34eda6790560b64292",
+        "is_verified": false,
+        "line_number": 3266,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "76f3759c722475003eaab60040d9a9dc21fc0cdc",
+        "is_verified": false,
+        "line_number": 3284,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9fa7674b3c2d42dd30528b2dea4cabb4d57bdd61",
+        "is_verified": false,
+        "line_number": 3290,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "817512f183bfc7decdead658917634e0108beae8",
+        "is_verified": false,
+        "line_number": 3299,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c5498b7d8a155b4be0174afbd40be7d282829c72",
+        "is_verified": false,
+        "line_number": 3318,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "90b7fe851b2d7b25aa1168ba4712fe365c45d3fe",
+        "is_verified": false,
+        "line_number": 3329,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6718fb2946d3061f3a538a8c552327d1c77e6d08",
+        "is_verified": false,
+        "line_number": 3339,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3169f32143dc39ea694b788e2b59c0b1d2634863",
+        "is_verified": false,
+        "line_number": 3349,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "d3cedc8271f9a3793779f05c64a6b9af66ae1cd7",
+        "is_verified": false,
+        "line_number": 3362,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fc40aa00be3d51c4350b945b5026da7995d62b49",
+        "is_verified": false,
+        "line_number": 3368,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "2a57a9814486d6f83257ec94e65d1024819611b8",
+        "is_verified": false,
+        "line_number": 3379,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6a7283084b5ad74635599d4a9fd19652649fde7e",
+        "is_verified": false,
+        "line_number": 3388,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ff6158d91155ecdc977baa1b5b216a02af9c165c",
+        "is_verified": false,
+        "line_number": 3397,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "82da7726f170885a2dc1da0b5c4b6817555ea5a6",
+        "is_verified": false,
+        "line_number": 3403,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "9ed00cfd866dca5ed0ae78a9c170a869026dc5a2",
+        "is_verified": false,
+        "line_number": 3412,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "0e28a4f732f9dd57bb658df2c1e0312cc9fec50f",
+        "is_verified": false,
+        "line_number": 3418,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5e5aae3e67acc7ee5f21262a2e65707566d2e10d",
+        "is_verified": false,
+        "line_number": 3437,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ec8a83737b73d60d903f68891f613a1d4d017aa9",
+        "is_verified": false,
+        "line_number": 3462,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fd37c9eea7199baa5ff067192c0c7e5e30de0c6e",
+        "is_verified": false,
+        "line_number": 3472,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "b9f57003f2209d754c7c6b969d25550a612f0234",
+        "is_verified": false,
+        "line_number": 3481,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3f1c898d451d544e8c5fa1466588624e180a876d",
+        "is_verified": false,
+        "line_number": 3487,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "6747c32810cbfd46083a580606e4c81addbc32b9",
+        "is_verified": false,
+        "line_number": 3496,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bfc0359487af3f6a3463d2bb61a7f08bc37891fa",
+        "is_verified": false,
+        "line_number": 3507,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "143652f1de98a755d843a070246a1066fc17b6cf",
+        "is_verified": false,
+        "line_number": 3519,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "23f4b7d3ee842d1d33ce1fa28dded8db962f8296",
+        "is_verified": false,
+        "line_number": 3529,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a9a6a8c29e7faf0679873c9583e0d8b9a91be698",
+        "is_verified": false,
+        "line_number": 3535,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "50607eb0d414d16617c90a7c615b98e1291f2c9a",
+        "is_verified": false,
+        "line_number": 3541,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fc8d1b8ff20199f725eb2dcb6e79eb3565cd1cfa",
+        "is_verified": false,
+        "line_number": 3547,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "23efd45ccd29d15988718abe09a7fde3d41ec4f8",
+        "is_verified": false,
+        "line_number": 3559,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "cee46f6961db7b18efbc3ebed86418294ceda04b",
+        "is_verified": false,
+        "line_number": 3568,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "efc8faf0216fa83e15fe88f378340bba786cd045",
+        "is_verified": false,
+        "line_number": 3577,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7801da9b235efc1864c0b42eb7a06a129cd5a1c1",
+        "is_verified": false,
+        "line_number": 3587,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3caf798428c37d7eefd08485086e94b3e2e88032",
+        "is_verified": false,
+        "line_number": 3598,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "56bbe3249c54dd16d92ef5e714c5aedbb00f68b0",
+        "is_verified": false,
+        "line_number": 3609,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ba80e2178d3f8d0f83f9f523cea0b3f384a1c6b1",
+        "is_verified": false,
+        "line_number": 3617,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "42e05c82cd06a9ed1d15e0f472c2efc4b3254cae",
+        "is_verified": false,
+        "line_number": 3624,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3b92b4a983c30abeed90eb2136069df54e82e6ef",
+        "is_verified": false,
+        "line_number": 3633,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "97bbbcdfd4f28594a283fe0983949446107210d5",
+        "is_verified": false,
+        "line_number": 3639,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "5782d0f39536b22f2c6aa29d3b815a57f43e4800",
+        "is_verified": false,
+        "line_number": 3649,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e47bf929659b7c2039fe03c774ddd5406ca1810c",
+        "is_verified": false,
+        "line_number": 3657,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "3e8398826cd9fe3add9d11633467029cdfafe3e8",
+        "is_verified": false,
+        "line_number": 3663,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7fbf450bf4ee54f013454f70af3a9743c0909f54",
+        "is_verified": false,
+        "line_number": 3680,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "46609edab29b7a6b294e201abea68299202ef319",
+        "is_verified": false,
+        "line_number": 3686,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a62c86915a1a70200fffecee3f3f8e4cfc8cb3b4",
+        "is_verified": false,
+        "line_number": 3692,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "af01cc91b84ec096e3397ba96829cfafc4835128",
+        "is_verified": false,
+        "line_number": 3698,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e60cb4cc2a256d22124924ae49d82308a2e88bcb",
+        "is_verified": false,
+        "line_number": 3710,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "98edcfe4785b579f5f11440ffc0bee6e3d78c842",
+        "is_verified": false,
+        "line_number": 3720,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "f8a877ddffebd2d16d5703b2212d2150fcb34043",
+        "is_verified": false,
+        "line_number": 3731,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a55c9f68d2edc144415ee059a69ac36ef064b794",
+        "is_verified": false,
+        "line_number": 3743,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "41d4f5514814504cc8ae5a5b5a064ddf09cf6403",
+        "is_verified": false,
+        "line_number": 3750,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "e49f18e87961da71563aa12e0bbc06d5dc179521",
+        "is_verified": false,
+        "line_number": 3771,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "139c3e672d846ea82d7a854d414bb196f5492220",
+        "is_verified": false,
+        "line_number": 3782,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7bbfa9cef1299fd23c1c45c2f497fb7ed80f40d9",
+        "is_verified": false,
+        "line_number": 3793,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "a0da6bf044cd8e994ffee3f46144c12837e93019",
+        "is_verified": false,
+        "line_number": 3805,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "bb6097d89f701b02d9014d81ae1c6a620632a914",
+        "is_verified": false,
+        "line_number": 3815,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "391f38936e47f2040f18d6877e02551cc79ba8b5",
+        "is_verified": false,
+        "line_number": 3829,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4cbb1abb4e2df6817983a320de24b842614761a8",
+        "is_verified": false,
+        "line_number": 3860,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8f4f18355e420103074e464e8b6791eae1791910",
+        "is_verified": false,
+        "line_number": 3879,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ed3eac062fd48c3964804d8a48eeda9b6c62ad16",
+        "is_verified": false,
+        "line_number": 3885,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8191798108137bb3aef3ebfbaa8723d0610c8b34",
+        "is_verified": false,
+        "line_number": 3896,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "7de38f7ccac58a4430e6dcbbda7ca020f6af9f41",
+        "is_verified": false,
+        "line_number": 3909,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "8db956011899a12e5f3cd3b6451ca77c5896f94d",
+        "is_verified": false,
+        "line_number": 3919,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fb0efd2d61c113c008a898abd9b1c9630705b752",
+        "is_verified": false,
+        "line_number": 3927,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "28ce4be9b6eb6856c4bf942b9951334e96a6c55a",
+        "is_verified": false,
+        "line_number": 3936,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "fb92558c941aa0776c2fe641ecfbb6b07e926ae2",
+        "is_verified": false,
+        "line_number": 3942,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "37680a8006c14300de69f22796f71085cee24615",
+        "is_verified": false,
+        "line_number": 3951,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "eca5fc6e4f5f895143d3fcedefc42dfe6e79f918",
+        "is_verified": false,
+        "line_number": 3962,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "845000390934a56f92bf868e699920b42663cbbe",
+        "is_verified": false,
+        "line_number": 3968,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "507daaba94790845911786926ea090c3d828a745",
+        "is_verified": false,
+        "line_number": 3974,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "c0665d268ee6985b4ce98c67b9c6c7502af11a25",
+        "is_verified": false,
+        "line_number": 3980,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "57709b8bfee092452a461c2436748a5767321643",
+        "is_verified": false,
+        "line_number": 3986,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "4fe989d609fb7f0841e2392bdd715829bb885af3",
+        "is_verified": false,
+        "line_number": 4005,
+        "type": "Base64 High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
https://github.com/alphagov/gds-pre-commit

All of the stuff in the secrets baseline file is just integrity check hashes from `package-lock.json`.