### PR TITLE
Update project version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Frontend functionality shared by the GovWifi websites",
   "main": "dist/govwifi-shared-frontend.js",
   "files": [


### PR DESCRIPTION
### What

Ensure the project version in the `package.json` matches the [latest release version in Github](https://github.com/alphagov/govwifi-shared-frontend/releases/tag/v0.6.7).

### Why

This is part of the package release process which I initially missed because the process isn't documented.