### PR TITLE
Update README with release process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+### What
+Describe the change
+
+### Why
+Describe why the change was necessary
+
+
+Link to Trello card (if applicable): 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Click ["Draft new release"](https://github.com/alphagov/govwifi-shared-frontend/
 
 ### Update GovWifi repos
 
-One the new version of the project has been released in GitHub, we need to update the `package.json` files in the GovWifi repos which use `govwifi-shared-frontend`.
+Once the new version of the project has been released in GitHub, we need to update the `package.json` files in the GovWifi repos which use `govwifi-shared-frontend`.
 
 * `govwifi-admin`
 * `govwifi-product-page`
@@ -115,7 +115,7 @@ For each of these projects, complete the following steps:
     ```
    Use the link address of the `.tgz` file found in the "Assets" section of the `govwifi-shared-frontend` ["Releases"](https://github.com/alphagov/govwifi-shared-frontend/releases) page. 
 3. Run `npm install` to pull in the new release. 
-4. Test the app locally to see if the update has caused an breaking changes.
+4. Test the app locally to see if the update has caused any breaking changes.
 5. Commit the changes (this should just be `package.json` and `package-lock.json`) and raise a PR.
 6. Once the PR is merged follow the stated deployment process for the repo.
 

--- a/README.md
+++ b/README.md
@@ -59,29 +59,13 @@ The release package must be uploaded to GitHub as part of the release process so
 
     This creates a “distribution” folder or `dist`. The `dist` contents are configured via webpack in the [`webpack.config.js`](webpack.config.js) file.
 
-2. Create an empty folder called `package` in the root project directory:
+2. Use `npm` to generate a compressed distribution package of the JS code which we will upload to GitHub:
  
     ```bash
-    $ mkdir package 
+    $ npm pack 
     ```
     
-    This will become the compressed package we upload to GitHub.
-
-3. Copy `dist/govwifi-shared-frontend.js`, `package.json`, `README.md`, and `LICENSE` into `package/`: 
-
-    ```bash
-    $ cp ./{dist/govwifi-shared-frontend.js,package.json,README.md,LICENSE} package
-    ```
- 
-4. From the root project directory, create a `.tgz` file of the `package/` folder, named `govwifi-shared-frontend-X.X.X` (where `X.X.X` is the release version for your release):
- 
-    ```bash
-     $ tar -cvf govwifi-shared-frontend-X.X.X.tgz package/
-    ```
-
-    This creates a compressed distribution package of the JS code, `package.json`, `README.md`, and `LICENSE` which we upload to GitHub. 
-
-    The unzipped file must be named `package` in order for it be installed and used by other GovWifi repos.
+    This will create a `.tgz` file at the directory’s root with a naming structure like this: `{name}-{release-version}.tgz`. 
 
 ### Update Github release version
 
@@ -93,7 +77,7 @@ Click ["Draft new release"](https://github.com/alphagov/govwifi-shared-frontend/
 2. Use the release version number for the "Release title"
 3. Add a useful description of the changes in the release, including links to Dependabot PRs if applicable.
 4. Click on "Attach binaries by dropping them here or selecting them."
-5. Attach the `govwifi-shared-frontend-X.X.X.tgz` file created earlier.
+5. Attach the `govwifi-shared-frontend-{release-version}.tgz` file created earlier.
 
 ### Update GovWifi repos
 
@@ -110,7 +94,7 @@ For each of these projects, complete the following steps:
     ```json
       "dependencies": {
         ...
-        "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/vX.X.X/govwifi-shared-frontend-X.X.X.tgz"
+        "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v{release-version}/govwifi-shared-frontend-{release-version}.tgz"
       },
     ```
    Use the link address of the `.tgz` file found in the "Assets" section of the `govwifi-shared-frontend` ["Releases"](https://github.com/alphagov/govwifi-shared-frontend/releases) page. 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # GovWifi Shared Frontend
 
 ## Description
-This package offers shared functionality across the three websites
-that make GovWifi (admin, product page, docs).
+This package offers shared functionality across the three websites that make GovWifi.
+
+`govwifi-shared-frontend` is used by:
+* [`govwifi-admin`](https://github.com/alphagov/govwifi-admin)
+* [`govwifi-product-page`](https://github.com/alphagov/govwifi-product-page)
+* [`govwifi-tech-docs`](https://github.com/alphagov/govwifi-tech-docs).
 
 ## Usage
 - `npm install govwifi-shared-frontend`;
@@ -29,7 +33,93 @@ will always return true).
 Amend the cookie policy to allow or disable the given
 `categoryName`. If `categoryName` is not recognised do nothing.
 
+## Release process
+
+### Update the code
+
+1. Create a branch from the main branch and make any necessary code or library updates.
+
+2. Update the “version” in [`package.json`](https://github.com/alphagov/govwifi-shared-frontend/blob/master/package.json#L3). Additional features or major code changes trigger a major version bump. Dependabot updates are minor release changes. For more information review [semantic versioning docs](https://semver.org/).  
+
+3. If you’ve updated any libraries run `npm install`. 
+
+    This will update the `package-lock.json` file which also must be committed.
+
+4. Raise a PR. Once approved, merge the PR into the main branch.
+
+### Build release package
+
+The release package must be uploaded to GitHub as part of the release process so it can be downloaded by the repos which use `govwifi-shared-frontend`.
+
+1. Run the following from the root project directory:
+
+    ```bash
+    $ npx webpack build --config ./webpack.config.js --stats verbose
+    ```
+
+    This creates a “distribution” folder or `dist`. The `dist` contents are configured via webpack in the [`webpack.config.js`](webpack.config.js) file.
+
+2. Create an empty folder called `package` in the root project directory:
+ 
+    ```bash
+    $ mkdir package 
+    ```
+    
+    This will become the compressed package we upload to GitHub.
+
+3. Copy `dist/govwifi-shared-frontend.js`, `package.json`, `README.md`, and `LICENSE` into `package/`: 
+
+    ```bash
+    $ cp ./{dist/govwifi-shared-frontend.js,package.json,README.md,LICENSE} package
+    ```
+ 
+4. From the root project directory, create a `.tgz` file of the `package/` folder, named `govwifi-shared-frontend-X.X.X` (where `X.X.X` is the release version for your release):
+ 
+    ```bash
+     $ tar -cvf govwifi-shared-frontend-X.X.X.tgz package/
+    ```
+
+    This creates a compressed distribution package of the JS code, `package.json`, `README.md`, and `LICENSE` which we upload to GitHub. 
+
+    The unzipped file must be named `package` in order for it be installed and used by other GovWifi repos.
+
+### Update Github release version
+
+Navigate to the `govwifi-shared-frontend` ["Releases"](https://github.com/alphagov/govwifi-shared-frontend/releases) page.
+
+Click ["Draft new release"](https://github.com/alphagov/govwifi-shared-frontend/releases/new), then follow the release version process:
+
+1. Under "Choose tag", create a new tag for the release or use an existing tag if it's appropriate.
+2. Use the release version number for the "Release title"
+3. Add a useful description of the changes in the release, including links to Dependabot PRs if applicable.
+4. Click on "Attach binaries by dropping them here or selecting them."
+5. Attach the `govwifi-shared-frontend-X.X.X.tgz` file created earlier.
+
+### Update GovWifi repos
+
+One the new version of the project has been released in GitHub, we need to update the `package.json` files in the GovWifi repos which use `govwifi-shared-frontend`.
+
+* `govwifi-admin`
+* `govwifi-product-page`
+* `govwifi-tech-docs`
+
+For each of these projects, complete the following steps:
+
+1. Create a new branch `update-govwifi-shared-frontend` from the main branch.
+2. In the repo's `package.json`, update the "govwifi-shared-frontend" dependency to point to the new release version: 
+    ```json
+      "dependencies": {
+        ...
+        "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/vX.X.X/govwifi-shared-frontend-X.X.X.tgz"
+      },
+    ```
+   Use the link address of the `.tgz` file found in the "Assets" section of the `govwifi-shared-frontend` ["Releases"](https://github.com/alphagov/govwifi-shared-frontend/releases) page. 
+3. Run `npm install` to pull in the new release. 
+4. Test the app locally to see if the update has caused an breaking changes.
+5. Commit the changes (this should just be `package.json` and `package-lock.json`) and raise a PR.
+6. Once the PR is merged follow the stated deployment process for the repo.
+
 ## TODO
 
-- [X] add webpack to streamline distribution;
-- [ ] add tests.
+- [X] add webpack to streamline distribution
+- [ ] add tests


### PR DESCRIPTION
### What

Update the README to include a comprehensive guide to release updates for the project.

Also add the team's pull request template.

### Why

This wasn't previously documented and it was difficult to figure out from scratch. I think it's also meant we haven't been updating the repos which use `govwifi-shared-frontend` because we lost the knowledge of how.

Adding the pull request template will make it easier for future contributors to automatically capture the what/why of a PR. It also aligns with the other GovWifi repos.

Thank you to @jimnarey for suggesting there was a more JS-friendly way to create the distribution package. I found `npm pack` and it was exactly what was needed.