### PR TITLE
Bump Version to 0.6.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govwifi-shared-frontend",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
         "js-cookie": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Frontend functionality shared by the GovWifi websites",
   "main": "dist/govwifi-shared-frontend.js",
   "files": [


### PR DESCRIPTION
### What
Bump Version to 0.6.9

### Why
So we can release a new version

