### PR TITLE
0.6.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govwifi-shared-frontend",
-      "version": "0.6.21",
+      "version": "0.6.22",
       "license": "MIT",
       "dependencies": {
         "js-cookie": "^3.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "description": "Frontend functionality shared by the GovWifi websites",
   "main": "dist/govwifi-shared-frontend.js",
   "files": [


### PR DESCRIPTION
### What
Previous deployment mandates a version bump to 0.6.22

### Why
Previous PR acceptance compat.

### Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
