### PR TITLE
0.6.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govwifi-shared-frontend",
-      "version": "0.6.22",
+      "version": "0.6.23",
       "license": "MIT",
       "dependencies": {
         "js-cookie": "^3.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "description": "Frontend functionality shared by the GovWifi websites",
   "main": "dist/govwifi-shared-frontend.js",
   "files": [


### PR DESCRIPTION
### What
Learning how to navigate the deploy process for govwifi-shared-frontend.

0.6.22 already exists it is claimed. Have run `npm version patch` again since I'll require this version to pull into the child repos.

### Why
0.6.22 already exists it is claimed.

### Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
