### PR TITLE
Fix dependabot message error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govwifi-shared-frontend",
-      "version": "0.6.24",
+      "version": "0.6.25",
       "license": "MIT",
       "dependencies": {
         "js-cookie": "^3.0.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govwifi-shared-frontend",
-      "version": "0.6.23",
+      "version": "0.6.24",
       "license": "MIT",
       "dependencies": {
         "js-cookie": "^3.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "description": "Frontend functionality shared by the GovWifi websites",
   "main": "dist/govwifi-shared-frontend.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govwifi-shared-frontend",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "description": "Frontend functionality shared by the GovWifi websites",
   "main": "dist/govwifi-shared-frontend.js",
   "files": [


### PR DESCRIPTION
### What
v0.6.25

### Why
To fix dependabot message error.

### Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
